### PR TITLE
feature/drupal11 compatibility - small

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ If deploying to Acquia Cloud, an easy way to do this is with a [secrets.settings
 Please contact the [ITS Help Desk](https://its.uiowa.edu/contact) for any support related to this module.
 
 ## Tests
-Tests should be run from the root of a Drupal 9 installation against the
-default site.
+Tests should be run from the root of a Drupal 10+ installation against the default site.
 
 To run test locally:
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Disables Drupal authentication and implements HawkID SSO.
 
 ## Requirements
-This module requires [drupal/samlauth](https://www.drupal.org/project/samlauth) version ^3.3 or later and all it's dependencies.
+This module requires [drupal/samlauth](https://www.drupal.org/project/samlauth) version ^3.13 or later and all it's dependencies.
 
 It also requires metadata describing the Service Provider (SP) endpoints to be consumed by the Identity Provider (IdP) in ITS. Drupal applications hosted in the uiowa subscription on Acquia Cloud can make use of an aggregate metadata file already in place. Please contact the ITS HelpDesk to get additional applications and domains added to the metadata.
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "description": "Disables Drupal authentication and implements HawkID SSO.",
     "type": "drupal-custom-module",
     "require": {
-        "drupal/samlauth": "^3.9",
+        "drupal/samlauth": "^3.13",
         "composer/installers": "^2.2",
         "drupal/externalauth": "^2.0"
     },

--- a/src/EventSubscriber/ExternalAuthSubscriber.php
+++ b/src/EventSubscriber/ExternalAuthSubscriber.php
@@ -66,7 +66,7 @@ class ExternalAuthSubscriber implements EventSubscriberInterface {
   /**
    * {@inheritdoc}
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     $events[ExternalAuthEvents::LOGIN][] = ['onUserLogin'];
     return $events;
   }

--- a/src/EventSubscriber/SamlauthSubscriber.php
+++ b/src/EventSubscriber/SamlauthSubscriber.php
@@ -68,7 +68,7 @@ class SamlauthSubscriber implements EventSubscriberInterface {
   /**
    * {@inheritdoc}
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     $events[SamlauthEvents::USER_SYNC][] = ['onUserSync'];
     $events[SamlauthEvents::USER_LINK][] = ['onUserLink'];
     return $events;

--- a/tests/build/composer.json
+++ b/tests/build/composer.json
@@ -11,7 +11,6 @@
         "drush/drush": "^12"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10",
         "drupal/core-dev": "^10.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
         "drupal/coder": "^8.3",

--- a/tests/build/composer.json
+++ b/tests/build/composer.json
@@ -14,7 +14,7 @@
         "drupal/core-dev": "^10.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
         "drupal/coder": "^8.3",
-        "mglaman/drupal-check": "^1.4",
+        "mglaman/drupal-check": "~1.3.1",
         "phpspec/prophecy-phpunit": "^2.0"
     },
     "extra": {

--- a/tests/build/composer.json
+++ b/tests/build/composer.json
@@ -6,20 +6,16 @@
         }
     },
     "require": {
-        "drupal/core-composer-scaffold": "^9.1",
-        "drupal/core": "^9.1",
-        "drush/drush": "^10"
+        "drupal/core-composer-scaffold": "^10.0",
+        "drupal/core-recommended": "^10.0",
+        "drush/drush": "^12"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9",
-        "behat/mink": "^1.7",
-        "behat/mink-goutte-driver": "^1.2",
-        "mikey179/vfsstream": "^1.6",
-        "symfony/phpunit-bridge": "^5.2",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
+        "phpunit/phpunit": "^10",
+        "drupal/core-dev": "^10.0",
+        "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
         "drupal/coder": "^8.3",
-        "mglaman/drupal-check": "~1.3.1",
-        "oomphinc/composer-installers-extender": "^2.0",
+        "mglaman/drupal-check": "^1.4",
         "phpspec/prophecy-phpunit": "^2.0"
     },
     "extra": {
@@ -39,10 +35,6 @@
             }
         }
     },
-    "scripts": {
-        "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
-        "post-install-cmd": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold"
-    },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "autoload-dev": {
@@ -56,7 +48,7 @@
             "composer/installers": true,
             "drupal/core-composer-scaffold": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
-            "oomphinc/composer-installers-extender": true
+            "phpstan/extension-installer": true
         }
     }
 }

--- a/tests/src/Kernel/HawkIDSettingsFormTest.php
+++ b/tests/src/Kernel/HawkIDSettingsFormTest.php
@@ -67,7 +67,7 @@ class HawkIDSettingsFormTest extends EntityKernelTestBase {
    *
    * @see testInvalidHawkIdForm()
    */
-  public function invalidValues() {
+  public static function invalidValues() {
     return [
       [
         'foo|bar',

--- a/uiowa_auth.info.yml
+++ b/uiowa_auth.info.yml
@@ -2,7 +2,7 @@ name: UIowa Authentication
 type: module
 description: Disables Drupal authentication and implements HawkID SSO.
 package: University of Iowa
-core_version_requirement: ^8 || ^9 || ^10
+core_version_requirement: ^8 || ^9 || ^10 || ^11
 dependencies:
   - samlauth:samlauth
   - externalauth:externalauth

--- a/uiowa_auth.info.yml
+++ b/uiowa_auth.info.yml
@@ -2,7 +2,7 @@ name: UIowa Authentication
 type: module
 description: Disables Drupal authentication and implements HawkID SSO.
 package: University of Iowa
-core_version_requirement: ^8 || ^9 || ^10 || ^11
+core_version_requirement: ^10 || ^11
 dependencies:
   - samlauth:samlauth
   - externalauth:externalauth


### PR DESCRIPTION
@pyrello 

We've been running uiowa_auth on Mediowa since April of 2025.  At the time I updated Mediowa to Drupal 11, I updated the module.  At the time I didn't know it was attached to a repository.  I just updated UIHC to Drupal 11, and started running into issues with compatibility when I pushed Drupal 11 to development.  Our development server is still pulling uiowa_auth from the repository, and overwriting my updates.  The updates are minor.

I made the updates according to the upgrade status module, and palantir/rector.  The only suggestions for the application made were the ones I added (adding return types to functions and changing one function to static).  Nothing else was required.

The updated version is running on https://medicineiowa.org/ and has been for 9 months.  And if you want to see how compatible the current module is without any code changes 2.0.1 is running on https://uihealthcare01dev.prod.acquia-sites.com/.  You can log in with no issues.  The only issue seems to be the module is flagged as being incompatible.

uiowa_auth has the following dependencies:
        "drupal/samlauth": "^3.9",
        "composer/installers": "^2.2",
        "drupal/externalauth": "^2.0"
        
Drupal 11 has the following dependencies:
        "drupal/samlauth": "^3.12",
        "composer/installers": "^2.2",
        "drupal/externalauth": "^2.0"