### PR TITLE
Merge 2.x back into main

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ If deploying to Acquia Cloud, an easy way to do this is with a [secrets.settings
 Please contact the [ITS Help Desk](https://its.uiowa.edu/contact) for any support related to this module.
 
 ## Tests
-Tests should be run from the root of a Drupal 9 installation against the
-default site.
+Tests should be run from the root of a Drupal 10+ installation against the default site.
 
 To run test locally:
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Disables Drupal authentication and implements HawkID SSO.
 
 ## Requirements
-This module requires [drupal/samlauth](https://www.drupal.org/project/samlauth) version ^3.3 or later and all it's dependencies.
+This module requires [drupal/samlauth](https://www.drupal.org/project/samlauth) version ^3.13 or later and all it's dependencies.
 
 It also requires metadata describing the Service Provider (SP) endpoints to be consumed by the Identity Provider (IdP) in ITS. Drupal applications hosted in the uiowa subscription on Acquia Cloud can make use of an aggregate metadata file already in place. Please contact the ITS HelpDesk to get additional applications and domains added to the metadata.
 

--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,9 @@
     "description": "Disables Drupal authentication and implements HawkID SSO.",
     "type": "drupal-custom-module",
     "require": {
-        "drupal/samlauth": "^3.3",
-        "composer/installers": "^2.1",
-        "drupal/externalauth": "^1.1"
+        "drupal/samlauth": "^3.9",
+        "composer/installers": "^2.2",
+        "drupal/externalauth": "^2.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "description": "Disables Drupal authentication and implements HawkID SSO.",
     "type": "drupal-custom-module",
     "require": {
-        "drupal/samlauth": "^3.9",
+        "drupal/samlauth": "^3.13",
         "composer/installers": "^2.2",
         "drupal/externalauth": "^2.0"
     },

--- a/src/EventSubscriber/ExternalAuthSubscriber.php
+++ b/src/EventSubscriber/ExternalAuthSubscriber.php
@@ -2,14 +2,14 @@
 
 namespace Drupal\uiowa_auth\EventSubscriber;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\externalauth\Authmap;
 use Drupal\externalauth\Event\ExternalAuthEvents;
 use Drupal\externalauth\Event\ExternalAuthLoginEvent;
-use Drupal\Core\Config\ConfigFactoryInterface;
-use Drupal\uiowa_auth\RoleMappings;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Psr\Log\LoggerInterface;
 use Drupal\samlauth\SamlService;
+use Drupal\uiowa_auth\RoleMappings;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * The uiowa event subscriber.

--- a/src/EventSubscriber/ExternalAuthSubscriber.php
+++ b/src/EventSubscriber/ExternalAuthSubscriber.php
@@ -66,7 +66,7 @@ class ExternalAuthSubscriber implements EventSubscriberInterface {
   /**
    * {@inheritdoc}
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     $events[ExternalAuthEvents::LOGIN][] = ['onUserLogin'];
     return $events;
   }

--- a/src/EventSubscriber/SamlauthSubscriber.php
+++ b/src/EventSubscriber/SamlauthSubscriber.php
@@ -2,16 +2,16 @@
 
 namespace Drupal\uiowa_auth\EventSubscriber;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\externalauth\Authmap;
 use Drupal\externalauth\Exception\ExternalAuthRegisterException;
 use Drupal\samlauth\Event\SamlauthEvents;
-use Drupal\samlauth\Event\SamlauthUserSyncEvent;
 use Drupal\samlauth\Event\SamlauthUserLinkEvent;
-use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\samlauth\Event\SamlauthUserSyncEvent;
 use Drupal\uiowa_auth\RoleMappings;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * The uiowa event subscriber.

--- a/src/EventSubscriber/SamlauthSubscriber.php
+++ b/src/EventSubscriber/SamlauthSubscriber.php
@@ -68,7 +68,7 @@ class SamlauthSubscriber implements EventSubscriberInterface {
   /**
    * {@inheritdoc}
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     $events[SamlauthEvents::USER_SYNC][] = ['onUserSync'];
     $events[SamlauthEvents::USER_LINK][] = ['onUserLink'];
     return $events;

--- a/tests/build/composer.json
+++ b/tests/build/composer.json
@@ -11,7 +11,6 @@
         "drush/drush": "^12"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10",
         "drupal/core-dev": "^10.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
         "drupal/coder": "^8.3",

--- a/tests/build/composer.json
+++ b/tests/build/composer.json
@@ -14,7 +14,7 @@
         "drupal/core-dev": "^10.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
         "drupal/coder": "^8.3",
-        "mglaman/drupal-check": "^1.4",
+        "mglaman/drupal-check": "~1.3.1",
         "phpspec/prophecy-phpunit": "^2.0"
     },
     "extra": {

--- a/tests/build/composer.json
+++ b/tests/build/composer.json
@@ -6,20 +6,16 @@
         }
     },
     "require": {
-        "drupal/core-composer-scaffold": "^9.1",
-        "drupal/core": "^9.1",
-        "drush/drush": "^10"
+        "drupal/core-composer-scaffold": "^10.0",
+        "drupal/core-recommended": "^10.0",
+        "drush/drush": "^12"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9",
-        "behat/mink": "^1.7",
-        "behat/mink-goutte-driver": "^1.2",
-        "mikey179/vfsstream": "^1.6",
-        "symfony/phpunit-bridge": "^5.2",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
+        "phpunit/phpunit": "^10",
+        "drupal/core-dev": "^10.0",
+        "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
         "drupal/coder": "^8.3",
-        "mglaman/drupal-check": "~1.3.1",
-        "oomphinc/composer-installers-extender": "^2.0",
+        "mglaman/drupal-check": "^1.4",
         "phpspec/prophecy-phpunit": "^2.0"
     },
     "extra": {
@@ -39,10 +35,6 @@
             }
         }
     },
-    "scripts": {
-        "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
-        "post-install-cmd": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold"
-    },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "autoload-dev": {
@@ -56,7 +48,7 @@
             "composer/installers": true,
             "drupal/core-composer-scaffold": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
-            "oomphinc/composer-installers-extender": true
+            "phpstan/extension-installer": true
         }
     }
 }

--- a/tests/src/Kernel/ExternalauthSubscriberTest.php
+++ b/tests/src/Kernel/ExternalauthSubscriberTest.php
@@ -2,9 +2,9 @@
 
 namespace Drupal\Tests\uiowa_auth\Kernel;
 
+use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
 use Drupal\uiowa_auth\EventSubscriber\ExternalAuthSubscriber;
 use Drupal\user\Entity\User;
-use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
 
 /**
  * Test description.

--- a/tests/src/Kernel/HawkIDSettingsFormTest.php
+++ b/tests/src/Kernel/HawkIDSettingsFormTest.php
@@ -3,8 +3,8 @@
 namespace Drupal\Tests\uiowa_auth\Kernel;
 
 use Drupal\Core\Form\FormState;
-use Drupal\uiowa_auth\Form\HawkIDSettingsForm;
 use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
+use Drupal\uiowa_auth\Form\HawkIDSettingsForm;
 
 /**
  * Test the HawkID settings form.

--- a/tests/src/Kernel/HawkIDSettingsFormTest.php
+++ b/tests/src/Kernel/HawkIDSettingsFormTest.php
@@ -67,7 +67,7 @@ class HawkIDSettingsFormTest extends EntityKernelTestBase {
    *
    * @see testInvalidHawkIdForm()
    */
-  public function invalidValues() {
+  public static function invalidValues() {
     return [
       [
         'foo|bar',

--- a/tests/src/Kernel/SamlauthSubscriberTest.php
+++ b/tests/src/Kernel/SamlauthSubscriberTest.php
@@ -2,9 +2,9 @@
 
 namespace Drupal\Tests\uiowa_auth\Kernel;
 
+use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
 use Drupal\uiowa_auth\EventSubscriber\SamlauthSubscriber;
 use Drupal\user\Entity\User;
-use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
 
 /**
  * Test description.

--- a/uiowa_auth.info.yml
+++ b/uiowa_auth.info.yml
@@ -2,7 +2,7 @@ name: UIowa Authentication
 type: module
 description: Disables Drupal authentication and implements HawkID SSO.
 package: University of Iowa
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^8 || ^9 || ^10
 dependencies:
   - samlauth:samlauth
   - externalauth:externalauth

--- a/uiowa_auth.info.yml
+++ b/uiowa_auth.info.yml
@@ -2,7 +2,7 @@ name: UIowa Authentication
 type: module
 description: Disables Drupal authentication and implements HawkID SSO.
 package: University of Iowa
-core_version_requirement: ^8 || ^9 || ^10
+core_version_requirement: ^8 || ^9 || ^10 || ^11
 dependencies:
   - samlauth:samlauth
   - externalauth:externalauth

--- a/uiowa_auth.info.yml
+++ b/uiowa_auth.info.yml
@@ -2,7 +2,7 @@ name: UIowa Authentication
 type: module
 description: Disables Drupal authentication and implements HawkID SSO.
 package: University of Iowa
-core_version_requirement: ^8 || ^9 || ^10 || ^11
+core_version_requirement: ^10 || ^11
 dependencies:
   - samlauth:samlauth
   - externalauth:externalauth


### PR DESCRIPTION
Discussed as part of https://github.com/uiowa/uiowa_auth/pull/12#issuecomment-3780876294.

Now that we don't have folks running different versions of PHP, we can go back to a `main` branch default with releases created off of that.